### PR TITLE
Updated paper-api to 1.20.1 and added MockBukkit test suites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,17 +17,11 @@
         </license>
     </licenses>
 
+    <!-- Developers listed below are members of the project's core development -->
     <developers>
         <developer>
             <name>Despical</name>
             <url>https://www.spigotmc.org/members/615094/</url>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-        <developer>
-            <name>gamerover98</name>
-            <url>https://www.spigotmc.org/resources/authors/gamerover98.27106/</url>
             <roles>
                 <role>developer</role>
             </roles>
@@ -48,9 +42,6 @@
             <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-
-        <!-- TEST -->
-
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -58,7 +49,6 @@
             <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.github.seeseemelk</groupId>
             <artifactId>MockBukkit-v1.20</artifactId>
@@ -71,7 +61,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,21 +25,58 @@
                 <role>developer</role>
             </roles>
         </developer>
+        <developer>
+            <name>gamerover98</name>
+            <url>https://www.spigotmc.org/resources/authors/gamerover98.27106/</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
     </developers>
 
     <repositories>
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 
     <dependencies>
         <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
+            <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- TEST -->
+
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.seeseemelk</groupId>
+            <artifactId>MockBukkit-v1.20</artifactId>
+            <version>3.19.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.16.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -97,6 +134,16 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.version>17</java.version>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/me/despical/commandframework/CommandFramework.java
+++ b/src/main/java/me/despical/commandframework/CommandFramework.java
@@ -84,7 +84,7 @@ public class CommandFramework implements CommandExecutor, TabCompleter {
 	 * Default command map of Bukkit.
 	 */
 	@Nullable
-	private CommandMap commandMap;
+	protected CommandMap commandMap;
 
 	// Error Message Handler
 	public static String ONLY_BY_PLAYERS         = ChatColor.RED + "This command is only executable by players!";

--- a/src/test/java/me/despical/commandframework/test/CommandFrameworkMock.java
+++ b/src/test/java/me/despical/commandframework/test/CommandFrameworkMock.java
@@ -1,0 +1,22 @@
+package me.despical.commandframework.test;
+
+import me.despical.commandframework.CommandFramework;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Mocked class of {@link CommandFramework}.
+ * @author gamerover98
+ */
+public class CommandFrameworkMock extends CommandFramework {
+
+	public CommandFrameworkMock(@NotNull Plugin plugin) {
+		super(plugin);
+
+		/*
+		 * There is no SimplePluginManager class in MockBukkit,
+		 * so the commandMap can be easily obtained from the ServerMock instance.
+		 */
+		this.commandMap = plugin.getServer().getCommandMap();
+	}
+}

--- a/src/test/java/me/despical/commandframework/test/CommandRegistrationTest.java
+++ b/src/test/java/me/despical/commandframework/test/CommandRegistrationTest.java
@@ -1,0 +1,128 @@
+package me.despical.commandframework.test;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.MockPlugin;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import me.despical.commandframework.Command;
+import me.despical.commandframework.CommandArguments;
+import me.despical.commandframework.CommandFramework;
+import me.despical.commandframework.Completer;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Command registration and usage test class.
+ * <p>
+ *     Implemented with <a href="https://github.com/MockBukkit/MockBukkit">MockBukkit</a>
+ * </p>
+ * @author gamerover98
+ */
+class CommandRegistrationTest {
+
+	/**
+	 * The {@link org.bukkit.Server} mocked instance.
+	 */
+	private ServerMock server;
+
+	/**
+	 * The {@link org.bukkit.plugin.java.JavaPlugin} mocked instance.
+	 */
+	private MockPlugin plugin;
+
+	@BeforeEach
+	public void setUp() {
+		server = MockBukkit.mock();
+		plugin = MockBukkit.createMockPlugin();
+	}
+
+	/**
+	 * Test to see if the {@link ExampleCommand} has been registered.
+	 */
+	@Test
+	void testCommandRegistration() {
+		CommandFramework commandFramework = createCommandFramework();
+		assertEquals(1, commandFramework.getCommands().size());
+	}
+
+	/**
+	 * Test to see if the {@link ExampleCommand} can be executed correctly by a {@link org.bukkit.entity.Player}.
+	 */
+	@Test
+	void testCommandExecutionByPlayer() {
+		createCommandFramework();
+		PlayerMock player = server.addPlayer();
+
+		// add as operator to prevent permission issues.
+		player.setOp(true);
+
+		// no params
+		player.performCommand("example");
+		player.assertSaid("§cRequired argument length is less or greater than needed!");
+
+		// one param
+		player.performCommand("example firstParam");
+		player.assertSaid("This is how you can create a example command using framework.");
+
+		//TODO: fix the execution of aliases and enable these tests.
+
+		// first alias
+		//player.performCommand("firstAlias");
+		//player.assertSaid("§cRequired argument length is less or greater than needed!");
+
+		// second alias
+		//player.performCommand("secondAlias");
+		//player.assertSaid("§cRequired argument length is less or greater than needed!");
+	}
+
+	@AfterEach
+	public void tearDown() {
+		MockBukkit.unmock();
+	}
+
+	/**
+	 * @return a {@link CommandFramework} instance with an example command.
+	 */
+	@NotNull
+	private CommandFramework createCommandFramework() {
+		CommandFramework commandFramework = new CommandFrameworkMock(plugin);
+		commandFramework.registerCommands(new ExampleCommand());
+		return commandFramework;
+	}
+
+	/**
+	 * Example command class like the
+	 * <a href="https://github.com/Despical/CommandFramework/wiki/Command-examples#example-usage">wiki one</a>
+	 */
+	public static class ExampleCommand {
+
+		@Command(
+			name = "example",
+			aliases = {"firstAlias", "secondAlias"},
+			permission = "example.permission",
+			desc = "Sends an example message to sender",
+			usage = "/example",
+			min = 1,
+			max = 5,
+			cooldown = 0, // no cooldown
+			senderType = Command.SenderType.BOTH
+		)
+		public void exampleCommandMethod(CommandArguments arguments) {
+			CommandSender sender = arguments.getSender();
+			sender.sendMessage("This is how you can create a example command using framework.");
+		}
+
+		@Completer(name = "example", aliases = {"firstAlias", "secondAlias"})
+		public List<String> exampleCommandCompletion(CommandArguments arguments) {
+			return Arrays.asList("first", "second", "third");
+		}
+	}
+}


### PR DESCRIPTION
### Description
Hi, in this pull request, you can find the updated paper-api (1.20.1) and a new test suite made with [MockBukkit](https://github.com/MockBukkit/MockBukkit) as mentioned in #5.

### Deprecation warning
As of the latest paper-api versions, the `org.bukkit.plugin.SimplePluginManager` has been marked as `@Deprecated(forRemoval = true)` and your IDE (I'm using IntelliJ IDEA) can be annoying.
![image](https://github.com/Despical/CommandFramework/assets/9408687/4f29ddd3-8b9f-437c-b0f5-1bacb1a1455d)
For the time being, just ignore it because it is not an error.

### Java version
1.20.1 required at least JDK 17 to be run. Don't worry, maven will compile it for JDK 8 as mentioned in the pom.xml 😄 

---
Looking forward to your feedback and collaboration on this enhancement.
Thank you